### PR TITLE
Refine behaviors and enforce initialization

### DIFF
--- a/Application/EnemyFactory.cs
+++ b/Application/EnemyFactory.cs
@@ -79,7 +79,9 @@ namespace app.enemy.app
             var ai = new TwinGoblinAI(ctx, move, combat, disp, cfg, td, pair?.Id ?? Guid.Empty);
             var core = new TwinGoblin(ctx.EnemyId, d.MaxHp, 0.3f, disp, pair?.Id ?? Guid.Empty);
 
-            return new EnemyDomainService(core, move, combat, ai, disp);
+            var unit = new EnemyDomainService(core, move, combat, ai, disp);
+            ai.Initialize(unit);
+            return unit;
         }
     }
 }

--- a/Domain/Interfaces/IEnemyInterfaces.cs
+++ b/Domain/Interfaces/IEnemyInterfaces.cs
@@ -24,6 +24,11 @@ namespace app.enemy.domain.interfaces
         /// 現在速度(m/s) デバッグ/アニメ制御用
         /// </summary>
         float CurrentSpeed { get; }
+
+        /// <summary>
+        /// 移動速度倍率を設定
+        /// </summary>
+        void SetSpeedMultiplier(float m);
     }
 
     /// <summary>
@@ -50,6 +55,11 @@ namespace app.enemy.domain.interfaces
         /// 次に使用できるまでの残り時間(秒)
         /// </summary>
         float CooldownRemaining { get; }
+
+        /// <summary>
+        /// 攻撃倍率を設定
+        /// </summary>
+        void SetAttackMultiplier(float m);
 
         event Action? OnAttack;
     }

--- a/Infrastructure/AI/BasicEnemyAI.cs
+++ b/Infrastructure/AI/BasicEnemyAI.cs
@@ -124,14 +124,12 @@ namespace app.enemy.ai
 
         protected void SetSpeedMultiplier(float m)
         {
-            if (_move is NavigationMoveLogic nav)
-                nav.SetSpeedMultiplier(m);
+            _move.SetSpeedMultiplier(m);
         }
 
         protected void SetAttackMultiplier(float m)
         {
-            if (_combat is SimpleCombatLogic sc)
-                sc.SetAttackMultiplier(m);
+            _combat.SetAttackMultiplier(m);
         }
 
         #endregion

--- a/Infrastructure/AI/BasicEnemyAI.cs
+++ b/Infrastructure/AI/BasicEnemyAI.cs
@@ -87,6 +87,12 @@ namespace app.enemy.ai
             _dispatcher.Register<EnemyDiedEvent>(OnEnemyDied);
         }
 
+        /// <summary>
+        /// Optional initialization hook for composed usage.
+        /// </summary>
+        /// <param name="unit">owning enemy unit</param>
+        public virtual void Initialize(IEnemyUnit unit) { }
+
         private void OnEnemyDied(EnemyDiedEvent e)
         {
             if (e.Id.Value != _ctx.EnemyId.Value) return;

--- a/Infrastructure/AI/BasicEnemyAI.cs
+++ b/Infrastructure/AI/BasicEnemyAI.cs
@@ -89,8 +89,12 @@ namespace app.enemy.ai
 
         /// <summary>
         /// Optional initialization hook for composed usage.
+        /// Call this when the AI instance is created via composition rather
+        /// than through inheritance so implementations can perform additional
+        /// setup. Derived types should override this to register events or
+        /// cache references related to the provided <paramref name="unit"/>.
         /// </summary>
-        /// <param name="unit">owning enemy unit</param>
+        /// <param name="unit">The owning enemy unit associated with this AI instance.</param>
         public virtual void Initialize(IEnemyUnit unit) { }
 
         private void OnEnemyDied(EnemyDiedEvent e)

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -17,7 +17,7 @@ namespace app.enemy.ai.behaviors
     {
         private readonly float _speedMul;
         private readonly float _atkMul;
-        private bool _enraged;
+        private volatile bool _enraged;
         private readonly object _lock = new();
         private bool _initialized;
         private bool _disposed;
@@ -26,7 +26,7 @@ namespace app.enemy.ai.behaviors
 
         public float SpeedMultiplier => _speedMul;
         public float AttackMultiplier => _atkMul;
-        public bool IsEnraged => _enraged;
+        public bool IsEnraged => Volatile.Read(ref _enraged);
         public bool IsInitialized
         {
             get

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using app.enemy.domain.interfaces;
 
 namespace app.enemy.ai.behaviors
@@ -18,7 +19,7 @@ namespace app.enemy.ai.behaviors
         private readonly float _atkMul;
         private bool _enraged;
         private readonly object _lock = new();
-        private bool _initialized;
+        private volatile bool _initialized;
         private bool _disposed;
         private IEnemyUnit? _enemy;
 
@@ -51,7 +52,7 @@ namespace app.enemy.ai.behaviors
 
         public void Update(float deltaTime)
         {
-            if (!_initialized) return;
+            if (!Volatile.Read(ref _initialized)) return;
 
             // No operation. This behavior is event-driven and does not
             // require per-frame updates.
@@ -61,7 +62,7 @@ namespace app.enemy.ai.behaviors
         {
             lock (_lock)
             {
-                if (!_initialized)
+                if (!Volatile.Read(ref _initialized))
                     throw new InvalidOperationException("EnrageBehavior must be initialized before triggering enrage.");
 
                 if (_enraged) return;

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -76,7 +76,6 @@ namespace app.enemy.ai.behaviors
             lock (_lock)
             {
                 if (_disposed) return;
-                _enemy = null;
                 _disposed = true;
             }
         }

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -32,7 +32,7 @@ namespace app.enemy.ai.behaviors
 
         public void Initialize(IEnemyUnit enemy)
         {
-            if (enemy == null) throw new ArgumentNullException(nameof(enemy));
+            ArgumentNullException.ThrowIfNull(enemy);
         }
 
         public void Update(float deltaTime)

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -51,7 +51,9 @@ namespace app.enemy.ai.behaviors
 
         public void Update(float deltaTime)
         {
-            // This behavior is event-driven and does not require per-frame updates.
+            // No operation. This behavior is event-driven and does not
+            // require per-frame updates.
+            return;
         }
 
         public void TriggerEnrage()

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -59,12 +59,15 @@ namespace app.enemy.ai.behaviors
 
         public void TriggerEnrage()
         {
+            if (!_initialized)
+                throw new InvalidOperationException("EnrageBehavior must be initialized before triggering enrage.");
+
             lock (_lock)
             {
                 if (_enraged) return;
                 _enraged = true;
+                OnEnrageTriggered?.Invoke();
             }
-            OnEnrageTriggered?.Invoke();
         }
 
         public void Dispose()

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -82,6 +82,9 @@ namespace app.enemy.ai.behaviors
         {
             lock (_lock)
             {
+                if (_disposed)
+                    throw new ObjectDisposedException(nameof(EnrageBehavior));
+
                 if (!_initialized)
                     throw new InvalidOperationException("EnrageBehavior must be initialized before triggering enrage.");
 

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -17,7 +17,6 @@ namespace app.enemy.ai.behaviors
         private readonly float _speedMul;
         private readonly float _atkMul;
         private bool _enraged;
-        private IEnemyUnit? _enemy;
 
         public event Action? OnEnrageTriggered;
 
@@ -33,7 +32,7 @@ namespace app.enemy.ai.behaviors
 
         public void Initialize(IEnemyUnit enemy)
         {
-            _enemy = enemy ?? throw new ArgumentNullException(nameof(enemy));
+            ArgumentNullException.ThrowIfNull(enemy);
         }
 
         public void Update(float deltaTime)

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -52,7 +52,7 @@ namespace app.enemy.ai.behaviors
 
         public void Update(float deltaTime)
         {
-            if (!Volatile.Read(ref _initialized)) return;
+            if (!_initialized) return;
 
             // No operation. This behavior is event-driven and does not
             // require per-frame updates.
@@ -62,7 +62,7 @@ namespace app.enemy.ai.behaviors
         {
             lock (_lock)
             {
-                if (!Volatile.Read(ref _initialized))
+                if (!_initialized)
                     throw new InvalidOperationException("EnrageBehavior must be initialized before triggering enrage.");
 
                 if (_enraged) return;

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -51,8 +51,7 @@ namespace app.enemy.ai.behaviors
 
         public void Update(float deltaTime)
         {
-            if (!_initialized)
-                throw new InvalidOperationException($"{nameof(EnrageBehavior)} must be initialized before calling {nameof(Update)}.");
+            if (!_initialized) return;
 
             // No operation. This behavior is event-driven and does not
             // require per-frame updates.

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -19,7 +19,7 @@ namespace app.enemy.ai.behaviors
         private readonly float _atkMul;
         private bool _enraged;
         private readonly object _lock = new();
-        private volatile bool _initialized;
+        private bool _initialized;
         private bool _disposed;
 
         public event Action? OnEnrageTriggered;
@@ -27,7 +27,16 @@ namespace app.enemy.ai.behaviors
         public float SpeedMultiplier => _speedMul;
         public float AttackMultiplier => _atkMul;
         public bool IsEnraged => _enraged;
-        public bool IsInitialized => _initialized;
+        public bool IsInitialized
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _initialized;
+                }
+            }
+        }
 
         public EnrageBehavior(float speedMultiplier, float attackMultiplier)
         {
@@ -51,7 +60,10 @@ namespace app.enemy.ai.behaviors
 
         public void Update(float deltaTime)
         {
-            if (!_initialized) return;
+            lock (_lock)
+            {
+                if (!_initialized || _disposed) return;
+            }
 
             // No operation. This behavior is event-driven and does not
             // require per-frame updates.

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -53,7 +53,6 @@ namespace app.enemy.ai.behaviors
         {
             // No operation. This behavior is event-driven and does not
             // require per-frame updates.
-            return;
         }
 
         public void TriggerEnrage()

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -17,6 +17,7 @@ namespace app.enemy.ai.behaviors
         private readonly float _speedMul;
         private readonly float _atkMul;
         private bool _enraged;
+        private IEnemyUnit? _enemy;
 
         public event Action? OnEnrageTriggered;
 
@@ -32,7 +33,7 @@ namespace app.enemy.ai.behaviors
 
         public void Initialize(IEnemyUnit enemy)
         {
-            ArgumentNullException.ThrowIfNull(enemy);
+            _enemy = enemy ?? throw new ArgumentNullException(nameof(enemy));
         }
 
         public void Update(float deltaTime)

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -35,7 +35,10 @@ namespace app.enemy.ai.behaviors
             if (enemy == null) throw new ArgumentNullException(nameof(enemy));
         }
 
-        public void Update(float deltaTime) { }
+        public void Update(float deltaTime)
+        {
+            // This behavior is event-driven and does not require per-frame updates.
+        }
 
         public void TriggerEnrage()
         {
@@ -44,6 +47,9 @@ namespace app.enemy.ai.behaviors
             OnEnrageTriggered?.Invoke();
         }
 
-        public void Dispose() { }
+        public void Dispose()
+        {
+            // No cleanup is needed as this class does not allocate unmanaged resources.
+        }
     }
 }

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -56,8 +56,11 @@ namespace app.enemy.ai.behaviors
 
         public void TriggerEnrage()
         {
-            if (_enraged) return;
-            _enraged = true;
+            lock (_lock)
+            {
+                if (_enraged) return;
+                _enraged = true;
+            }
             OnEnrageTriggered?.Invoke();
         }
 

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -17,6 +17,7 @@ namespace app.enemy.ai.behaviors
         private readonly float _speedMul;
         private readonly float _atkMul;
         private bool _enraged;
+        private IEnemyUnit? _enemy;
 
         public event Action? OnEnrageTriggered;
 
@@ -33,6 +34,7 @@ namespace app.enemy.ai.behaviors
         public void Initialize(IEnemyUnit enemy)
         {
             ArgumentNullException.ThrowIfNull(enemy);
+            _enemy = enemy;
         }
 
         public void Update(float deltaTime)

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -17,7 +17,6 @@ namespace app.enemy.ai.behaviors
         private readonly float _speedMul;
         private readonly float _atkMul;
         private bool _enraged;
-        private IEnemyUnit? _enemy;
 
         public event Action? OnEnrageTriggered;
 
@@ -33,7 +32,7 @@ namespace app.enemy.ai.behaviors
 
         public void Initialize(IEnemyUnit enemy)
         {
-            _enemy = enemy ?? throw new ArgumentNullException(nameof(enemy));
+            if (enemy == null) throw new ArgumentNullException(nameof(enemy));
         }
 
         public void Update(float deltaTime) { }

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -51,9 +51,8 @@ namespace app.enemy.ai.behaviors
 
         public void Dispose()
         {
-            // Reset fields for consistency, though no unmanaged resources are allocated.
+            // Release references; this behavior is not meant to be reused after disposal.
             _enemy = null;
-            _enraged = false;
         }
     }
 }

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -17,7 +17,7 @@ namespace app.enemy.ai.behaviors
     {
         private readonly float _speedMul;
         private readonly float _atkMul;
-        private volatile bool _enraged;
+        private bool _enraged;
         private readonly object _lock = new();
         private bool _initialized;
         private bool _disposed;
@@ -26,7 +26,16 @@ namespace app.enemy.ai.behaviors
 
         public float SpeedMultiplier => _speedMul;
         public float AttackMultiplier => _atkMul;
-        public bool IsEnraged => Volatile.Read(ref _enraged);
+        public bool IsEnraged
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _enraged;
+                }
+            }
+        }
         public bool IsInitialized
         {
             get

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -51,7 +51,9 @@ namespace app.enemy.ai.behaviors
 
         public void Dispose()
         {
-            // No cleanup is needed as this class does not allocate unmanaged resources.
+            // Reset fields for consistency, though no unmanaged resources are allocated.
+            _enemy = null;
+            _enraged = false;
         }
     }
 }

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -21,13 +21,13 @@ namespace app.enemy.ai.behaviors
         private readonly object _lock = new();
         private volatile bool _initialized;
         private bool _disposed;
-        private IEnemyUnit? _enemy;
 
         public event Action? OnEnrageTriggered;
 
         public float SpeedMultiplier => _speedMul;
         public float AttackMultiplier => _atkMul;
         public bool IsEnraged => _enraged;
+        public bool IsInitialized => _initialized;
 
         public EnrageBehavior(float speedMultiplier, float attackMultiplier)
         {
@@ -45,7 +45,6 @@ namespace app.enemy.ai.behaviors
 
                 if (_initialized) return;
 
-                _enemy = enemy;
                 _initialized = true;
             }
         }

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -59,11 +59,11 @@ namespace app.enemy.ai.behaviors
 
         public void TriggerEnrage()
         {
-            if (!_initialized)
-                throw new InvalidOperationException("EnrageBehavior must be initialized before triggering enrage.");
-
             lock (_lock)
             {
+                if (!_initialized)
+                    throw new InvalidOperationException("EnrageBehavior must be initialized before triggering enrage.");
+
                 if (_enraged) return;
                 _enraged = true;
                 OnEnrageTriggered?.Invoke();

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -51,6 +51,9 @@ namespace app.enemy.ai.behaviors
 
         public void Update(float deltaTime)
         {
+            if (!_initialized)
+                throw new InvalidOperationException($"{nameof(EnrageBehavior)} must be initialized before calling {nameof(Update)}.");
+
             // No operation. This behavior is event-driven and does not
             // require per-frame updates.
         }

--- a/Infrastructure/AI/Behaviors/EnrageBehavior.cs
+++ b/Infrastructure/AI/Behaviors/EnrageBehavior.cs
@@ -1,0 +1,50 @@
+using System;
+using app.enemy.domain.interfaces;
+
+namespace app.enemy.ai.behaviors
+{
+    public interface IEnrageBehavior : IEnemyBehavior
+    {
+        event Action OnEnrageTriggered;
+        float SpeedMultiplier { get; }
+        float AttackMultiplier { get; }
+        bool IsEnraged { get; }
+        void TriggerEnrage();
+    }
+
+    public sealed class EnrageBehavior : IEnrageBehavior
+    {
+        private readonly float _speedMul;
+        private readonly float _atkMul;
+        private bool _enraged;
+        private IEnemyUnit? _enemy;
+
+        public event Action? OnEnrageTriggered;
+
+        public float SpeedMultiplier => _speedMul;
+        public float AttackMultiplier => _atkMul;
+        public bool IsEnraged => _enraged;
+
+        public EnrageBehavior(float speedMultiplier, float attackMultiplier)
+        {
+            _speedMul = speedMultiplier;
+            _atkMul = attackMultiplier;
+        }
+
+        public void Initialize(IEnemyUnit enemy)
+        {
+            _enemy = enemy ?? throw new ArgumentNullException(nameof(enemy));
+        }
+
+        public void Update(float deltaTime) { }
+
+        public void TriggerEnrage()
+        {
+            if (_enraged) return;
+            _enraged = true;
+            OnEnrageTriggered?.Invoke();
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -21,7 +21,7 @@ namespace app.enemy.ai.behaviors
     public sealed class PairBehavior : IPairBehavior
     {
         private readonly DomainEventDispatcher _dispatcher;
-        private EnemyId _pairId;
+        private readonly EnemyId _pairId;
         private IDisposable? _token;
         private bool _initialized;
         private IEnemyUnit? _enemy;

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -15,7 +15,7 @@ namespace app.enemy.ai.behaviors
     public interface IPairBehavior : IEnemyBehavior
     {
         event Action<EnemyId> OnPairMemberDied;
-        bool IsPaired { get; }
+        bool IsInitialized { get; }
     }
 
     public sealed class PairBehavior : IPairBehavior
@@ -28,7 +28,7 @@ namespace app.enemy.ai.behaviors
 
         public event Action<EnemyId>? OnPairMemberDied;
 
-        public bool IsPaired => _initialized;
+        public bool IsInitialized => _initialized;
 
         public PairBehavior(DomainEventDispatcher dispatcher, EnemyId pairId)
         {
@@ -46,6 +46,7 @@ namespace app.enemy.ai.behaviors
 
         private void OnTwinMateDead(TwinMateDeedEvent e)
         {
+            if (!_initialized || _enemy == null) return;
             if (e.PairId != _pairId) return;
             if (e.Id == _enemy.Id) return;
             OnPairMemberDied?.Invoke(e.Id);

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -66,15 +66,13 @@ namespace app.enemy.ai.behaviors
 
         private void OnTwinMateDead(TwinMateDeedEvent e)
         {
-            EnemyId id;
             lock (_lock)
             {
                 if (!_initialized || _disposed) return;
                 if (e.PairId != _pairId) return;
                 if (_enemy == null || e.Id == _enemy.Id) return;
-                id = e.Id;
+                OnPairMemberDied?.Invoke(e.Id);
             }
-            OnPairMemberDied?.Invoke(id);
         }
 
         public void Update(float deltaTime)

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -78,7 +78,6 @@ namespace app.enemy.ai.behaviors
                 if (_disposed) return;
                 _token?.Dispose();
                 _token = null;
-                _enemy = null;
                 _disposed = true;
             }
         }

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using app.enemy.domain;
 using app.enemy.domain.events;
 using app.enemy.domain.interfaces;
@@ -24,7 +25,7 @@ namespace app.enemy.ai.behaviors
         private readonly EnemyId _pairId;
         private readonly object _lock = new();
         private IDisposable? _token;
-        private bool _initialized;
+        private volatile bool _initialized;
         private bool _disposed;
         private IEnemyUnit? _enemy;
 
@@ -56,7 +57,7 @@ namespace app.enemy.ai.behaviors
 
         private void OnTwinMateDead(TwinMateDeedEvent e)
         {
-            if (!_initialized) return;
+            if (!Volatile.Read(ref _initialized)) return;
             if (e.PairId != _pairId) return;
             if (_enemy == null || e.Id == _enemy.Id) return;
             OnPairMemberDied?.Invoke(e.Id);
@@ -64,7 +65,7 @@ namespace app.enemy.ai.behaviors
 
         public void Update(float deltaTime)
         {
-            if (!_initialized) return;
+            if (!Volatile.Read(ref _initialized)) return;
 
             // No operation. This behavior reacts to domain events and
             // requires no per-frame logic.

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -1,0 +1,64 @@
+using System;
+using app.enemy.domain;
+using app.enemy.domain.events;
+using app.enemy.domain.interfaces;
+
+namespace app.enemy.ai.behaviors
+{
+    public interface IEnemyBehavior
+    {
+        void Initialize(IEnemyUnit enemy);
+        void Update(float deltaTime);
+        void Dispose();
+    }
+
+    public interface IPairBehavior : IEnemyBehavior
+    {
+        event Action<EnemyId> OnPairMemberDied;
+        bool IsPaired { get; }
+    }
+
+    public sealed class PairBehavior : IPairBehavior
+    {
+        private readonly DomainEventDispatcher _dispatcher;
+        private EnemyId _pairId;
+        private IDisposable? _token;
+        private bool _initialized;
+        private IEnemyUnit? _enemy;
+
+        public event Action<EnemyId>? OnPairMemberDied;
+
+        public bool IsPaired => _initialized;
+
+        public PairBehavior(DomainEventDispatcher dispatcher, EnemyId pairId)
+        {
+            _dispatcher = dispatcher;
+            _pairId = pairId;
+        }
+
+        public void Initialize(IEnemyUnit enemy)
+        {
+            if (_initialized) return;
+            _enemy = enemy ?? throw new ArgumentNullException(nameof(enemy));
+            _initialized = true;
+            _token = _dispatcher.Register<TwinMateDeedEvent>(OnTwinMateDead);
+        }
+
+        private void OnTwinMateDead(TwinMateDeedEvent e)
+        {
+            if (e.PairId != _pairId) return;
+            if (_enemy != null && e.Id == _enemy.Id) return;
+            OnPairMemberDied?.Invoke(e.Id);
+        }
+
+        public void Update(float deltaTime)
+        {
+            // behavior is event-driven, no per-frame logic
+        }
+
+        public void Dispose()
+        {
+            _token?.Dispose();
+        }
+    }
+}

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -64,9 +64,9 @@ namespace app.enemy.ai.behaviors
 
         public void Update(float deltaTime)
         {
-            // behavior is event-driven, no per-frame logic
-            // This method is intentionally left empty because the PairBehavior
-            // class reacts to domain events rather than per-frame updates.
+            // No operation. This behavior reacts to domain events and
+            // requires no per-frame logic.
+            return;
         }
 
         public void Dispose()

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -71,7 +71,7 @@ namespace app.enemy.ai.behaviors
                 _token?.Dispose();
                 _token = null;
                 _enemy = null;
-                // Object is not expected to be reinitialized after disposal
+                _initialized = false;
             }
         }
     }

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -57,7 +57,7 @@ namespace app.enemy.ai.behaviors
 
         private void OnTwinMateDead(TwinMateDeedEvent e)
         {
-            if (!Volatile.Read(ref _initialized)) return;
+            if (!_initialized) return;
             if (e.PairId != _pairId) return;
             if (_enemy == null || e.Id == _enemy.Id) return;
             OnPairMemberDied?.Invoke(e.Id);
@@ -65,7 +65,7 @@ namespace app.enemy.ai.behaviors
 
         public void Update(float deltaTime)
         {
-            if (!Volatile.Read(ref _initialized)) return;
+            if (!_initialized) return;
 
             // No operation. This behavior reacts to domain events and
             // requires no per-frame logic.

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -71,6 +71,7 @@ namespace app.enemy.ai.behaviors
                 _token?.Dispose();
                 _token = null;
                 _enemy = null;
+                _initialized = false;
                 // Object is not expected to be reinitialized after disposal
             }
         }

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -54,6 +54,8 @@ namespace app.enemy.ai.behaviors
         public void Update(float deltaTime)
         {
             // behavior is event-driven, no per-frame logic
+            // This method is intentionally left empty because the PairBehavior
+            // class reacts to domain events rather than per-frame updates.
         }
 
         public void Dispose()

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -71,7 +71,7 @@ namespace app.enemy.ai.behaviors
                 _token?.Dispose();
                 _token = null;
                 _enemy = null;
-                _initialized = false;
+                // Object is not expected to be reinitialized after disposal
             }
         }
     }

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -66,7 +66,6 @@ namespace app.enemy.ai.behaviors
         {
             // No operation. This behavior reacts to domain events and
             // requires no per-frame logic.
-            return;
         }
 
         public void Dispose()

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -47,7 +47,7 @@ namespace app.enemy.ai.behaviors
         private void OnTwinMateDead(TwinMateDeedEvent e)
         {
             if (e.PairId != _pairId) return;
-            if (_enemy != null && e.Id == _enemy.Id) return;
+            if (e.Id == _enemy.Id) return;
             OnPairMemberDied?.Invoke(e.Id);
         }
 

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -58,7 +58,7 @@ namespace app.enemy.ai.behaviors
         {
             if (!_initialized) return;
             if (e.PairId != _pairId) return;
-            if (e.Id == _enemy!.Id) return;
+            if (_enemy == null || e.Id == _enemy.Id) return;
             OnPairMemberDied?.Invoke(e.Id);
         }
 

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -71,7 +71,7 @@ namespace app.enemy.ai.behaviors
                 _token?.Dispose();
                 _token = null;
                 _enemy = null;
-                _initialized = false;
+                // Do not reset _initialized to avoid reusing a disposed instance.
             }
         }
     }

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -71,7 +71,6 @@ namespace app.enemy.ai.behaviors
                 _token?.Dispose();
                 _token = null;
                 _enemy = null;
-                _initialized = false;
                 // Object is not expected to be reinitialized after disposal
             }
         }

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -58,7 +58,7 @@ namespace app.enemy.ai.behaviors
         {
             if (!_initialized) return;
             if (e.PairId != _pairId) return;
-            if (_enemy == null || e.Id == _enemy.Id) return;
+            if (e.Id == _enemy!.Id) return;
             OnPairMemberDied?.Invoke(e.Id);
         }
 

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -64,6 +64,8 @@ namespace app.enemy.ai.behaviors
 
         public void Update(float deltaTime)
         {
+            if (!_initialized) return;
+
             // No operation. This behavior reacts to domain events and
             // requires no per-frame logic.
         }

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -8,6 +8,7 @@ namespace app.enemy.ai.behaviors
 {
     public interface IEnemyBehavior
     {
+        bool IsInitialized { get; }
         void Initialize(IEnemyUnit enemy);
         void Update(float deltaTime);
         void Dispose();
@@ -16,7 +17,6 @@ namespace app.enemy.ai.behaviors
     public interface IPairBehavior : IEnemyBehavior
     {
         event Action<EnemyId> OnPairMemberDied;
-        bool IsInitialized { get; }
     }
 
     public sealed class PairBehavior : IPairBehavior

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -70,8 +70,10 @@ namespace app.enemy.ai.behaviors
             {
                 if (!_initialized || _disposed) return;
                 if (e.PairId != _pairId) return;
-                System.Diagnostics.Debug.Assert(_enemy != null, "Invariant violated: _enemy should not be null when _initialized is true.");
-                if (e.Id == _enemy!.Id) return;
+                if (_enemy == null)
+                    throw new InvalidOperationException("Invariant violated: _enemy should not be null when _initialized is true.");
+
+                if (e.Id == _enemy.Id) return;
                 OnPairMemberDied?.Invoke(e.Id);
             }
         }

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -70,7 +70,7 @@ namespace app.enemy.ai.behaviors
             {
                 if (!_initialized || _disposed) return;
                 if (e.PairId != _pairId) return;
-                if (_enemy == null || e.Id == _enemy.Id) return;
+                if (e.Id == _enemy!.Id) return;
                 OnPairMemberDied?.Invoke(e.Id);
             }
         }

--- a/Infrastructure/AI/Behaviors/PairBehavior.cs
+++ b/Infrastructure/AI/Behaviors/PairBehavior.cs
@@ -70,6 +70,7 @@ namespace app.enemy.ai.behaviors
             {
                 if (!_initialized || _disposed) return;
                 if (e.PairId != _pairId) return;
+                System.Diagnostics.Debug.Assert(_enemy != null, "Invariant violated: _enemy should not be null when _initialized is true.");
                 if (e.Id == _enemy!.Id) return;
                 OnPairMemberDied?.Invoke(e.Id);
             }

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -67,13 +67,8 @@ namespace app.enemy.ai
         public void Tick(float dt)
         {
             if (!Volatile.Read(ref _initialized))
-            {
-                lock (_lock)
-                {
-                    if (!Volatile.Read(ref _initialized))
-                        throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
-                }
-            }
+                throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
+
             _baseAI.Tick(dt);
             _pairBehavior.Update(dt);
             _enrageBehavior.Update(dt);

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -70,7 +70,6 @@ namespace app.enemy.ai
                     _baseAI.Dispose();
                     _pairBehavior.Dispose();
                     _enrageBehavior.Dispose();
-                    _initialized = false;
                     throw;
                 }
             }
@@ -79,13 +78,7 @@ namespace app.enemy.ai
         public void Tick(float dt)
         {
             if (!_initialized)
-            {
-                lock (_lock)
-                {
-                    if (!_initialized)
-                        throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
-                }
-            }
+                throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
 
             _baseAI.Tick(dt);
             _pairBehavior.Update(dt);

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -51,8 +51,7 @@ namespace app.enemy.ai
 
         public void Initialize(IEnemyUnit unit)
         {
-            if (unit == null)
-                throw new ArgumentNullException(nameof(unit));
+            ArgumentNullException.ThrowIfNull(unit);
             if (_initialized) return;
             _baseAI.Initialize(unit);
             _pairBehavior.Initialize(unit);

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -66,7 +66,7 @@ namespace app.enemy.ai
 
         public void Tick(float dt)
         {
-            if (!Volatile.Read(ref _initialized))
+            if (!_initialized)
                 throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
 
             _baseAI.Tick(dt);

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -161,9 +161,32 @@ namespace app.enemy.ai
                 _disposed = true;
             }
 
-            _enrageBehavior.Dispose();
-            _pairBehavior.Dispose();
-            _baseAI.Dispose();
+            try
+            {
+                _enrageBehavior.Dispose();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Exception during _enrageBehavior.Dispose(): {ex}");
+            }
+
+            try
+            {
+                _pairBehavior.Dispose();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Exception during _pairBehavior.Dispose(): {ex}");
+            }
+
+            try
+            {
+                _baseAI.Dispose();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Exception during _baseAI.Dispose(): {ex}");
+            }
         }
     }
 }

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -82,19 +82,7 @@ namespace app.enemy.ai
                 {
                     Trace.TraceError($"Failed to initialize {step}: {ex.Message}");
 
-                    // clean up already-initialized behaviors in reverse order
-                    switch (step)
-                    {
-                        case InitStep.EnrageBehavior:
-                            _enrageBehavior.Dispose();
-                            goto case InitStep.PairBehavior;
-                        case InitStep.PairBehavior:
-                            _pairBehavior.Dispose();
-                            goto case InitStep.BaseAI;
-                        case InitStep.BaseAI:
-                            _baseAI.Dispose();
-                            break;
-                    }
+                    CleanupInitializedBehaviors(step);
                     throw;
                 }
             }
@@ -126,6 +114,16 @@ namespace app.enemy.ai
             _move.SetSpeedMultiplier(_enrageBehavior.SpeedMultiplier);
             _combat.SetAttackMultiplier(_enrageBehavior.AttackMultiplier);
             _dispatcher.Dispatch(new TwinEnragedEvent(_ctx.EnemyId));
+        }
+
+        private void CleanupInitializedBehaviors(InitStep step)
+        {
+            if (step >= InitStep.EnrageBehavior)
+                _enrageBehavior.Dispose();
+            if (step >= InitStep.PairBehavior)
+                _pairBehavior.Dispose();
+            if (step >= InitStep.BaseAI)
+                _baseAI.Dispose();
         }
 
         public void Dispose()

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -70,7 +70,7 @@ namespace app.enemy.ai
             {
                 lock (_lock)
                 {
-                    if (!_initialized)
+                    if (!Volatile.Read(ref _initialized))
                         throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
                 }
             }

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -87,13 +87,10 @@ namespace app.enemy.ai
                     {
                         case InitStep.EnrageBehavior:
                             _enrageBehavior.Dispose();
-                            _pairBehavior.Dispose();
-                            _baseAI.Dispose();
-                            break;
+                            goto case InitStep.PairBehavior;
                         case InitStep.PairBehavior:
                             _pairBehavior.Dispose();
-                            _baseAI.Dispose();
-                            break;
+                            goto case InitStep.BaseAI;
                         case InitStep.BaseAI:
                             _baseAI.Dispose();
                             break;
@@ -107,6 +104,9 @@ namespace app.enemy.ai
         {
             lock (_lock)
             {
+                if (_disposed)
+                    throw new ObjectDisposedException(nameof(TwinGoblinAI), "Cannot call Tick on a disposed TwinGoblinAI instance.");
+
                 if (!_initialized)
                     throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
 

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -66,7 +66,8 @@ namespace app.enemy.ai
 
         public void Tick(float dt)
         {
-            if (!_initialized) throw new InvalidOperationException("TwinGoblinAI is not initialized");
+            if (!_initialized)
+                throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
             _baseAI.Tick(dt);
             _pairBehavior.Update(dt);
             _enrageBehavior.Update(dt);

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -4,6 +4,7 @@
 /// <author>CGC_10_田中 ミノル</author>
 
 using System;
+using System.Threading;
 using app.enemy.ai.behaviors;
 using app.enemy.data;
 using app.enemy.domain;
@@ -65,7 +66,7 @@ namespace app.enemy.ai
 
         public void Tick(float dt)
         {
-            if (!_initialized)
+            if (!Volatile.Read(ref _initialized))
             {
                 lock (_lock)
                 {

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -66,7 +66,7 @@ namespace app.enemy.ai
 
         public void Tick(float dt)
         {
-            if (!_initialized)
+            if (!Volatile.Read(ref _initialized))
                 throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
 
             _baseAI.Tick(dt);
@@ -81,19 +81,9 @@ namespace app.enemy.ai
 
         private void OnEnrageTriggered()
         {
-            SetSpeedMultiplier(_enrageBehavior.SpeedMultiplier);
-            SetAttackMultiplier(_enrageBehavior.AttackMultiplier);
+            _move.SetSpeedMultiplier(_enrageBehavior.SpeedMultiplier);
+            _combat.SetAttackMultiplier(_enrageBehavior.AttackMultiplier);
             _dispatcher.Dispatch(new TwinEnragedEvent(_ctx.EnemyId));
-        }
-
-        private void SetSpeedMultiplier(float m)
-        {
-            _move.SetSpeedMultiplier(m);
-        }
-
-        private void SetAttackMultiplier(float m)
-        {
-            _combat.SetAttackMultiplier(m);
         }
 
         public void Dispose()

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -66,8 +66,11 @@ namespace app.enemy.ai
 
         public void Tick(float dt)
         {
-            if (!Volatile.Read(ref _initialized))
-                throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
+            lock (_lock)
+            {
+                if (!_initialized)
+                    throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
+            }
 
             _baseAI.Tick(dt);
             _pairBehavior.Update(dt);

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -65,10 +65,13 @@ namespace app.enemy.ai
 
         public void Tick(float dt)
         {
-            lock (_lock)
+            if (!_initialized)
             {
-                if (!_initialized)
-                    throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
+                lock (_lock)
+                {
+                    if (!_initialized)
+                        throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
+                }
             }
             _baseAI.Tick(dt);
             _pairBehavior.Update(dt);
@@ -99,7 +102,7 @@ namespace app.enemy.ai
 
         public void Dispose()
         {
-            (_baseAI as IDisposable)?.Dispose();
+            _baseAI.Dispose();
             _pairBehavior.Dispose();
             _enrageBehavior.Dispose();
         }

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -65,8 +65,11 @@ namespace app.enemy.ai
 
         public void Tick(float dt)
         {
-            if (!_initialized)
-                throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
+            lock (_lock)
+            {
+                if (!_initialized)
+                    throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
+            }
             _baseAI.Tick(dt);
             _pairBehavior.Update(dt);
             _enrageBehavior.Update(dt);

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -24,6 +24,7 @@ namespace app.enemy.ai
         private readonly IAIContext _ctx;
         private readonly IPairBehavior _pairBehavior;
         private readonly IEnrageBehavior _enrageBehavior;
+        private readonly object _lock = new();
         private bool _initialized;
 
         public TwinGoblinAI(
@@ -53,10 +54,14 @@ namespace app.enemy.ai
         {
             ArgumentNullException.ThrowIfNull(unit);
             if (_initialized) return;
-            _baseAI.Initialize(unit);
-            _pairBehavior.Initialize(unit);
-            _enrageBehavior.Initialize(unit);
-            _initialized = true;
+            lock (_lock)
+            {
+                if (_initialized) return;
+                _baseAI.Initialize(unit);
+                _pairBehavior.Initialize(unit);
+                _enrageBehavior.Initialize(unit);
+                _initialized = true;
+            }
         }
 
         public void Tick(float dt)

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -71,10 +71,20 @@ namespace app.enemy.ai
                 }
                 catch (Exception ex)
                 {
-                    Trace.TraceError($"Failed to initialize {step}: {ex.Message}", ex);
+                    Trace.TraceError($"Failed to initialize {step}: {ex.Message}\n{ex.StackTrace}");
+
+                    // clean up already-initialized behaviors in reverse order
+                    if (step == nameof(_enrageBehavior))
+                    {
+                        _pairBehavior.Dispose();
+                        _baseAI.Dispose();
+                    }
+                    else if (step == nameof(_pairBehavior))
+                    {
+                        _baseAI.Dispose();
+                    }
+
                     _enrageBehavior.Dispose();
-                    _pairBehavior.Dispose();
-                    _baseAI.Dispose();
                     throw;
                 }
             }

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -71,7 +71,7 @@ namespace app.enemy.ai
                 }
                 catch (Exception ex)
                 {
-                    Trace.TraceError($"Failed to initialize {step}: {ex}");
+                    Trace.TraceError($"Failed to initialize {step}: {ex.Message}", ex);
                     _enrageBehavior.Dispose();
                     _pairBehavior.Dispose();
                     _baseAI.Dispose();

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -20,6 +20,8 @@ namespace app.enemy.ai
         private readonly BasicEnemyAI _baseAI;
         private readonly IMoveLogic _move;
         private readonly ICombatLogic _combat;
+        private readonly DomainEventDispatcher _dispatcher;
+        private readonly IAIContext _ctx;
         private readonly IPairBehavior _pairBehavior;
         private readonly IEnrageBehavior _enrageBehavior;
         private bool _initialized;
@@ -33,8 +35,10 @@ namespace app.enemy.ai
             TwinGoblinUserData src,
             Guid pair)
         {
+            _ctx = ctx;
             _move = move;
             _combat = combat;
+            _dispatcher = dispatcher;
             _baseAI = new BasicEnemyAI(ctx, move, combat, dispatcher, cfg);
 
             _pairBehavior = new PairBehavior(dispatcher, new EnemyId(pair));
@@ -50,6 +54,7 @@ namespace app.enemy.ai
             if (unit == null)
                 throw new ArgumentNullException(nameof(unit));
             if (_initialized) return;
+            _baseAI.Initialize(unit);
             _pairBehavior.Initialize(unit);
             _enrageBehavior.Initialize(unit);
             _initialized = true;
@@ -72,6 +77,7 @@ namespace app.enemy.ai
         {
             SetSpeedMultiplier(_enrageBehavior.SpeedMultiplier);
             SetAttackMultiplier(_enrageBehavior.AttackMultiplier);
+            _dispatcher.Dispatch(new TwinEnragedEvent(_ctx.EnemyId));
         }
 
         private void SetSpeedMultiplier(float m)

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -57,19 +57,34 @@ namespace app.enemy.ai
             lock (_lock)
             {
                 if (_initialized) return;
-                _baseAI.Initialize(unit);
-                _pairBehavior.Initialize(unit);
-                _enrageBehavior.Initialize(unit);
-                _initialized = true;
+
+                try
+                {
+                    _baseAI.Initialize(unit);
+                    _pairBehavior.Initialize(unit);
+                    _enrageBehavior.Initialize(unit);
+                    _initialized = true;
+                }
+                catch
+                {
+                    _baseAI.Dispose();
+                    _pairBehavior.Dispose();
+                    _enrageBehavior.Dispose();
+                    _initialized = false;
+                    throw;
+                }
             }
         }
 
         public void Tick(float dt)
         {
-            lock (_lock)
+            if (!_initialized)
             {
-                if (!_initialized)
-                    throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
+                lock (_lock)
+                {
+                    if (!_initialized)
+                        throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
+                }
             }
 
             _baseAI.Tick(dt);

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -4,6 +4,7 @@
 /// <author>CGC_10_田中 ミノル</author>
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using app.enemy.ai.behaviors;
 using app.enemy.data;
@@ -58,19 +59,22 @@ namespace app.enemy.ai
             {
                 if (_initialized) return;
 
+                string step = nameof(_baseAI);
                 try
                 {
                     _baseAI.Initialize(unit);
+                    step = nameof(_pairBehavior);
                     _pairBehavior.Initialize(unit);
+                    step = nameof(_enrageBehavior);
                     _enrageBehavior.Initialize(unit);
                     _initialized = true;
                 }
                 catch (Exception ex)
                 {
-                    Console.Error.WriteLine($"Error during initialization: {ex}");
-                    _baseAI.Dispose();
-                    _pairBehavior.Dispose();
+                    Trace.TraceError($"Failed to initialize {step}: {ex}");
                     _enrageBehavior.Dispose();
+                    _pairBehavior.Dispose();
+                    _baseAI.Dispose();
                     throw;
                 }
             }

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -80,7 +80,7 @@ namespace app.enemy.ai
                 }
                 catch (Exception ex)
                 {
-                    Trace.TraceError($"Failed to initialize {step}: {ex.Message}");
+                    Trace.TraceError($"Failed to initialize {step}: {ex}");
 
                     CleanupInitializedBehaviors(step);
                     throw;
@@ -119,11 +119,38 @@ namespace app.enemy.ai
         private void CleanupInitializedBehaviors(InitStep step)
         {
             if (step >= InitStep.EnrageBehavior)
-                _enrageBehavior.Dispose();
+            {
+                try
+                {
+                    _enrageBehavior.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Exception during _enrageBehavior.Dispose(): {ex}");
+                }
+            }
             if (step >= InitStep.PairBehavior)
-                _pairBehavior.Dispose();
+            {
+                try
+                {
+                    _pairBehavior.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Exception during _pairBehavior.Dispose(): {ex}");
+                }
+            }
             if (step >= InitStep.BaseAI)
-                _baseAI.Dispose();
+            {
+                try
+                {
+                    _baseAI.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Exception during _baseAI.Dispose(): {ex}");
+                }
+            }
         }
 
         public void Dispose()

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -25,7 +25,7 @@ namespace app.enemy.ai
         private readonly IPairBehavior _pairBehavior;
         private readonly IEnrageBehavior _enrageBehavior;
         private readonly object _lock = new();
-        private bool _initialized;
+        private volatile bool _initialized;
 
         public TwinGoblinAI(
             IAIContext ctx,

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -65,8 +65,9 @@ namespace app.enemy.ai
                     _enrageBehavior.Initialize(unit);
                     _initialized = true;
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Console.Error.WriteLine($"Error during initialization: {ex}");
                     _baseAI.Dispose();
                     _pairBehavior.Dispose();
                     _enrageBehavior.Dispose();

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -4,62 +4,91 @@
 /// <author>CGC_10_田中 ミノル</author>
 
 using System;
-using System.Collections.Generic;
+using app.enemy.ai.behaviors;
 using app.enemy.data;
 using app.enemy.domain;
-using app.enemy.domain.enums;
 using app.enemy.domain.events;
 using app.enemy.domain.interfaces;
-using via;
-using via.attribute;
+using app.enemy.infrastructure;
 
 namespace app.enemy.ai
 {
     public readonly record struct PairLink(Guid Id);
 
-    public sealed class TwinGoblinAI : BasicEnemyAI
+    public sealed class TwinGoblinAI : IEnemyAi, IDisposable
     {
-        private readonly EnemyId _pairId;
-        private readonly Func<float> _enrageSpeedMul;
-        private readonly Func<float> _enrageAtkMul;
-        private readonly GameObject _enragedTarget;
-        private readonly DomainEventDispatcher _disp;
-        private readonly IAIContext _ctx;
-        private bool _enraged;
+        private readonly BasicEnemyAI _baseAI;
+        private readonly IMoveLogic _move;
+        private readonly ICombatLogic _combat;
+        private readonly IPairBehavior _pairBehavior;
+        private readonly IEnrageBehavior _enrageBehavior;
+        private bool _initialized;
 
-        public TwinGoblinAI(IAIContext ctx, IMoveLogic move, ICombatLogic combat, DomainEventDispatcher dispatcher, BasicEnemyAI.Config cfg, TwinGoblinUserData src, Guid pair)
-            : base(ctx, move, combat, dispatcher, cfg)
+        public TwinGoblinAI(
+            IAIContext ctx,
+            IMoveLogic move,
+            ICombatLogic combat,
+            DomainEventDispatcher dispatcher,
+            BasicEnemyAI.Config cfg,
+            TwinGoblinUserData src,
+            Guid pair)
         {
-            _enrageSpeedMul = () => src.EnrageSpeedMul;
-            _enrageAtkMul = () => src.EnrageAttackMul;
-            _ctx = ctx;
-            _disp = dispatcher;
-            _enragedTarget = src.EnragedTarget.Target;
-            _pairId = new EnemyId(pair);
+            _move = move;
+            _combat = combat;
+            _baseAI = new BasicEnemyAI(ctx, move, combat, dispatcher, cfg);
 
-            // TODO: 少女を取得し _enragedTarget に格納
-            _disp.Register<TwinMateDeedEvent>(OnMateDied);
-            _disp.Register<TwinMateDeedEvent>(OnSelfDied);
+            _pairBehavior = new PairBehavior(dispatcher, new EnemyId(pair));
+
+            _enrageBehavior = new EnrageBehavior(src.EnrageSpeedMul, src.EnrageAttackMul);
+
+            _pairBehavior.OnPairMemberDied += _ => OnPairMemberDied();
+            _enrageBehavior.OnEnrageTriggered += OnEnrageTriggered;
         }
 
-        void OnSelfDied(TwinMateDeedEvent e)
+        public void Initialize(IEnemyUnit unit)
         {
-            if (e.Id.Value != _ctx.EnemyId.Value) return;
-            if (Current == AiState.Dead) return;
-            SwitchState(AiState.Dead);
+            if (unit == null)
+                throw new ArgumentNullException(nameof(unit));
+            if (_initialized) return;
+            _pairBehavior.Initialize(unit);
+            _enrageBehavior.Initialize(unit);
+            _initialized = true;
         }
 
-        void OnMateDied(TwinMateDeedEvent e)
+        public void Tick(float dt)
         {
-            if (_enraged || e.PairId != _pairId || e.Id == _ctx.EnemyId) return;
+            if (!_initialized) throw new InvalidOperationException("TwinGoblinAI is not initialized");
+            _baseAI.Tick(dt);
+            _pairBehavior.Update(dt);
+            _enrageBehavior.Update(dt);
+        }
 
-            _enraged = true;
-            SetSpeedMultiplier(_enrageSpeedMul());
-            SetAttackMultiplier(_enrageAtkMul());
+        private void OnPairMemberDied()
+        {
+            _enrageBehavior.TriggerEnrage();
+        }
 
-            // TODO: ターゲットの変更
+        private void OnEnrageTriggered()
+        {
+            SetSpeedMultiplier(_enrageBehavior.SpeedMultiplier);
+            SetAttackMultiplier(_enrageBehavior.AttackMultiplier);
+        }
 
-            _disp.Dispatch(new TwinEnragedEvent(_ctx.EnemyId));
+        private void SetSpeedMultiplier(float m)
+        {
+            _move.SetSpeedMultiplier(m);
+        }
+
+        private void SetAttackMultiplier(float m)
+        {
+            _combat.SetAttackMultiplier(m);
+        }
+
+        public void Dispose()
+        {
+            (_baseAI as IDisposable)?.Dispose();
+            _pairBehavior.Dispose();
+            _enrageBehavior.Dispose();
         }
     }
 }

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -53,7 +53,6 @@ namespace app.enemy.ai
         public void Initialize(IEnemyUnit unit)
         {
             ArgumentNullException.ThrowIfNull(unit);
-            if (_initialized) return;
             lock (_lock)
             {
                 if (_initialized) return;

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -80,7 +80,7 @@ namespace app.enemy.ai
                 }
                 catch (Exception ex)
                 {
-                    Trace.TraceError($"Failed to initialize {step}: {ex.Message}\n{ex.StackTrace}");
+                    Trace.TraceError($"Failed to initialize {step}: {ex.Message}");
 
                     // clean up already-initialized behaviors in reverse order
                     switch (step)
@@ -109,11 +109,11 @@ namespace app.enemy.ai
             {
                 if (!_initialized)
                     throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
-            }
 
-            _baseAI.Tick(dt);
-            _pairBehavior.Update(dt);
-            _enrageBehavior.Update(dt);
+                _baseAI.Tick(dt);
+                _pairBehavior.Update(dt);
+                _enrageBehavior.Update(dt);
+            }
         }
 
         private void OnPairMemberDied()

--- a/Infrastructure/AI/TwinGoblinAI.cs
+++ b/Infrastructure/AI/TwinGoblinAI.cs
@@ -66,11 +66,8 @@ namespace app.enemy.ai
 
         public void Tick(float dt)
         {
-            lock (_lock)
-            {
-                if (!_initialized)
-                    throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
-            }
+            if (!Volatile.Read(ref _initialized))
+                throw new InvalidOperationException("TwinGoblinAI must be initialized before calling Tick. Call Initialize() first.");
 
             _baseAI.Tick(dt);
             _pairBehavior.Update(dt);


### PR DESCRIPTION
## Summary
- simplify PairBehavior and EnrageBehavior disposal
- add initialization checks in TwinGoblinAI

## Testing
- `dotnet build -nologo` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_6878c076e9648323a26ac15ee31c663e